### PR TITLE
fix: CI SSM DescribeParameters + VPC endpoints (ssm, ssmmessages, kms)

### DIFF
--- a/infra/deploy/network.tf
+++ b/infra/deploy/network.tf
@@ -11,13 +11,15 @@ locals {
     "10.127.128.0/24",
     "10.127.129.0/24"
   ]
-
-  # Map of interface endpoints
+  
+  # Map of interface endpoints for private subnets (no NAT).
   interface_endpoints = {
-    ecr        = "com.amazonaws.${data.aws_region.current.region}.ecr.api"
-    dkr        = "com.amazonaws.${data.aws_region.current.region}.ecr.dkr"
-    cloudwatch = "com.amazonaws.${data.aws_region.current.region}.logs"
-    ssm        = "com.amazonaws.${data.aws_region.current.region}.ssmmessages"
+    ecr         = "com.amazonaws.${data.aws_region.current.region}.ecr.api"
+    dkr         = "com.amazonaws.${data.aws_region.current.region}.ecr.dkr"
+    cloudwatch  = "com.amazonaws.${data.aws_region.current.region}.logs"
+    ssm         = "com.amazonaws.${data.aws_region.current.region}.ssm"
+    ssmmessages = "com.amazonaws.${data.aws_region.current.region}.ssmmessages"
+    kms         = "com.amazonaws.${data.aws_region.current.region}.kms"
   }
 }
 

--- a/infra/setup/iam_cicd_prod.tf
+++ b/infra/setup/iam_cicd_prod.tf
@@ -498,6 +498,8 @@ resource "aws_iam_policy" "cicd_gha_ssm_params_policy" {
   policy      = data.aws_iam_policy_document.cicd_gha_ssm_params_policy.json
 }
 data "aws_iam_policy_document" "cicd_gha_ssm_params_policy" {
+  # DescribeParameters is evaluated against arn:aws:ssm:region:account:* and cannot be
+  # scoped to parameter path ARNs (unlike PutParameter / GetParameter).
   statement {
     sid    = "ManageParameters"
     effect = "Allow"
@@ -506,7 +508,6 @@ data "aws_iam_policy_document" "cicd_gha_ssm_params_policy" {
       "ssm:DeleteParameter",
       "ssm:GetParameter",
       "ssm:GetParameters",
-      "ssm:DescribeParameters",
       "ssm:AddTagsToResource",
       "ssm:RemoveTagsFromResource",
       "ssm:ListTagsForResource",
@@ -527,6 +528,18 @@ data "aws_iam_policy_document" "cicd_gha_ssm_params_policy" {
     resources = [
       aws_kms_key.kms_secrets.arn,
     ]
+  }
+  statement {
+    sid       = "ListKMSAliases"
+    effect    = "Allow"
+    actions   = ["kms:ListAliases"]
+    resources = ["*"]
+  }
+  statement {
+    sid       = "DescribeParameters"
+    effect    = "Allow"
+    actions   = ["ssm:DescribeParameters"]
+    resources = ["*"]
   }
 }
 resource "aws_iam_role_policy_attachment" "cicd_gha_ssm_params_policy" {


### PR DESCRIPTION
Two focused fixes on top of current `main`:

1. **`infra/setup/iam_cicd_prod.tf`** — `ssm:DescribeParameters` on `*` (required for Terraform refresh); `kms:ListAliases` for KMS alias resolution; keep parameter mutations scoped to `parameter/recipe-api-*`.

2. **`infra/deploy/network.tf`** — Correct interface endpoints for private Fargate: `ssm` (Parameter Store), `ssmmessages` (Session Manager / ECS Exec), `kms` (CMK-encrypted SecureStrings).

Branch was reset to `origin/main` and the two commits were cherry-picked so the PR contains only these files.

Made with [Cursor](https://cursor.com)